### PR TITLE
allows to empty local_net for a specified transport

### DIFF
--- a/functions.inc/drivers/PJSip.class.php
+++ b/functions.inc/drivers/PJSip.class.php
@@ -873,7 +873,11 @@ class PJSip extends \FreePBX\modules\Core\Drivers\Sip {
 				// If there's a specific local net for this interface, add it too.
 				$localnet = $this->freepbx->Sipsettings->getConfig($protocol."localnet-$ip");
 				if ($localnet) {
-					$transport[$t]['local_net'][] =  $localnet;
+					if ($localnet === 'none') {
+						$transport[$t]['local_net'] = [];
+					} else {
+						$transport[$t]['local_net'][] =  $localnet;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Flexisip requires a custom transport with no local_net configured. With this pull request, is possible to clean all globally configured local_net for a transport specifying "none" as localnet

nethesis/dev#5904